### PR TITLE
Update style.css - fix primary section content to full width when no-sidebar present

### DIFF
--- a/apostrophe-2/style.css
+++ b/apostrophe-2/style.css
@@ -3208,7 +3208,7 @@ Very large tablets in landscape mode and most desktops.
 	.page.apostrophe-2-no-sidebar #primary {
 		float: none;
 		margin: 0 auto;
-		width: 730px;
+		width: 100%;
 	}
 
 	.blog.apostrophe-2-no-sidebar #primary,


### PR DESCRIPTION
Fixes #primary section width to full width 100% when no sidebar is present.
(The intention of this class as per the comment in the code on line 3206 was to set the content to full width, but is defined at 730px)

_**To replicate:**_
Install apostrophe-2 Automattic theme [https://wordpress.com/theme/apostrophe-2]
Create page with default template
Remove or hide all widgets
_**Result :**_
Although page defaults to full-width the `#primary` section content is too narrow
<img width="1645" alt="Screen Shot 2020-04-27 at 15 04 53" src="https://user-images.githubusercontent.com/3121582/80370299-840be500-8898-11ea-86b1-f7c7342b0577.png">

<!-- Thanks for contributing to our free themes! Please provide as much information as possible with your Pull Request by filling out the following - this helps make reviewing much quicker! -->

#### Changes proposed in this Pull Request:
Edit line 3211 of style.css - Changes `width:730px` to `width:100%`
https://github.com/Automattic/themes/blob/master/apostrophe-2/style.css

#### Related issue(s):
